### PR TITLE
Fix page not found bug on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,13 +14,9 @@ def create_app(test_config=None):
         app.logger.info('Processing default request')
         return 'Hello, World!'
 
-    @app.route('/endpoint1')
-    def endpoint1():
-        return 'This is endpoint 1.'
-
-    @app.route('/endpoint2')
-    def endpoint2():
-        return 'This is endpoint 2.'
+    @app.route('/favicon.ico')
+    def favicon():
+        return '', 204
     
     @app.errorhandler(404)
     def page_not_found(e):


### PR DESCRIPTION
On startup, the browser is searching for favicon.ico route. I want to return nothing for this route and not throw an error. Secondly, I removed the other routes 'example1' and 'example2' as they are not necessary.