### PR TITLE
Added support for local_dev dynamic on deploy

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ def create_app():
         app.config['DEBUG'] = True
 
     # Usage:
-    secrets_manager_client = SecretsManagerClient(logger=logger,local_dev=True)
+    secrets_manager_client = SecretsManagerClient(logger=logger,local_dev=local_dev)
     sample = None
     secret = secrets_manager_client.get_secret("prod/airtable_oauth")
     if secret:


### PR DESCRIPTION
I previously was declaring local_dev=False, where it broke on deploy because the profile='kieran_dev' could not be found. I have now made it dynamic.